### PR TITLE
Fixed Jinja2 template lookup compatibilty with Windows.

### DIFF
--- a/watson/framework/views/renderers/jinja2.py
+++ b/watson/framework/views/renderers/jinja2.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import importlib
+from pathlib import Path
 import types
 import jinja2
 from watson.common import datastructures
@@ -311,6 +312,6 @@ class Renderer(abc.Renderer):
 
     def __call__(self, view_model, context=None):
         template = self._env.get_template(
-            '{0}.{1}'.format(view_model.template,
+            '{0}.{1}'.format(Path(view_model.template).as_posix(),
                              self.config['extension']))
         return template.render(context=context or {}, **view_model.data)


### PR DESCRIPTION
I've added explicit conversion to POSIX path for Jinja2 renderer.

Note that I use pathlib's Path and as_posix(), which are available only in Python 3.4.
