### PR TITLE
Python 3 compatible fix of Jinja2 template lookup

### DIFF
--- a/watson/framework/views/renderers/jinja2.py
+++ b/watson/framework/views/renderers/jinja2.py
@@ -311,6 +311,6 @@ class Renderer(abc.Renderer):
 
     def __call__(self, view_model, context=None):
         template = self._env.get_template(
-            '{0}.{1}'.format(view_model.template,
+            '{0}.{1}'.format(view_model.template.replace('\\', '/'),
                              self.config['extension']))
         return template.render(context=context or {}, **view_model.data)


### PR DESCRIPTION
Fixed Jinja2 template lookup compatibility with Windows. 

Unlike the previous solution (https://github.com/watsonpy/watson-framework/pull/7) it is compatible with Python 3, but it's clearly a dirty hack.
