### PR TITLE
doc: Fixing routes example

### DIFF
--- a/docs/common-usage/controllers.rst
+++ b/docs/common-usage/controllers.rst
@@ -20,7 +20,7 @@ Action controller methods are defined explicitly within the applications route c
     routes = {
         'index': {
             'path': '/',
-            'defaults': {'controller': 'app_name.controllers.Public', 'action': 'index'}
+            'options': {'controller': 'app_name.controllers.Public', 'action': 'index'}
         },
     }
 
@@ -46,7 +46,7 @@ RESTful controller methods are based upon the HTTP request method that was made 
     routes = {
         'index': {
             'path': '/',
-            'defaults': {'controller': 'app_name.controllers.User'}
+            'options': {'controller': 'app_name.controllers.User'}
         },
     }
 


### PR DESCRIPTION
The given example requires key 'options' to be used in routes configuration. With key 'defaults', Watson won't find the required controllers.

Signed-of: Jan Tulak <jan@tulak.me>